### PR TITLE
Fix all npm high audit warnings by updating packages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testURL: 'http://localhost/'
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ module.exports = function (options) {
 	let base_url = options.base_url || false;
 	let method = options.method || false;
 	let protocol = options.protocol || false;
-	let response_code = options.response_code || false;
+	let response_code_all = options.response_code || false;
+	let response_code_individual = options.response_code_individual || false;
 	let DELIM = options.delim || '-';
 	let REGEX_PIPE = /\|/g;
 
@@ -56,10 +57,13 @@ module.exports = function (options) {
 				statTags.push(`path:${req.path}`);
 			}
 
-			if (response_code) {
+			if (response_code_all) {
 				statTags.push(`response_code:${res.statusCode}`);
-				datadog.increment(`${stat}.response_code.${res.statusCode}`, 1, statTags);
 				datadog.increment(`${stat}.response_code.all`, 1, statTags);
+			}
+
+			if (response_code_individual) {
+				datadog.increment(`${stat}.response_code.${res.statusCode}`, 1, statTags);
 			}
 
 			datadog.histogram(`${stat}.response_time`, new Date() - req._startTime, 1, statTags);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,79 +5,85 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
-			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.40"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
-			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				}
 			}
 		},
 		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
 			"dev": true
 		},
 		"acorn": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-			"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
+			"integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.4.1"
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
 		},
-		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"dev": true,
-			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
-			}
-		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
-			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
-			}
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
 			"dev": true
 		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
 		"ansi-escapes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -87,22 +93,298 @@
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
 			}
 		},
 		"append-transform": {
@@ -111,7 +393,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"argparse": {
@@ -120,7 +402,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -129,13 +411,19 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
 		"array-equal": {
@@ -157,15 +445,24 @@
 			"dev": true
 		},
 		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
 		"astral-regex": {
@@ -175,12 +472,12 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.17.11"
 			}
 		},
 		"async-limiter": {
@@ -195,6 +492,12 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -202,9 +505,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
 		"babel-code-frame": {
@@ -213,9 +516,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -230,11 +533,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -243,7 +546,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -255,30 +558,30 @@
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.8",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -287,14 +590,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.5",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			}
 		},
 		"babel-helpers": {
@@ -303,18 +606,18 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
-			"integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.5",
-				"babel-preset-jest": "22.4.1"
+				"babel-plugin-istanbul": "^4.1.5",
+				"babel-preset-jest": "^22.4.4"
 			}
 		},
 		"babel-messages": {
@@ -323,24 +626,25 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.9.2",
-				"test-exclude": "4.2.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"test-exclude": "^4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
-			"integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
 			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
@@ -350,13 +654,13 @@
 			"dev": true
 		},
 		"babel-preset-jest": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
-			"integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "22.4.1",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+				"babel-plugin-jest-hoist": "^22.4.4",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-register": {
@@ -365,13 +669,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.5",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"source-map-support": {
@@ -380,7 +684,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "^0.5.6"
 					}
 				}
 			}
@@ -391,8 +695,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.3",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -401,11 +705,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -414,15 +718,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.3",
-				"lodash": "4.17.5"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-types": {
@@ -431,10 +735,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.5",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -449,23 +753,80 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"brace-expansion": {
@@ -474,7 +835,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -484,21 +845,21 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"browser-process-hrtime": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
 			"dev": true
 		},
 		"browser-resolve": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
 			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
@@ -510,14 +871,39 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
-		"builtin-modules": {
+		"buffer-from": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
 		},
 		"callsites": {
 			"version": "2.0.0",
@@ -526,11 +912,19 @@
 			"dev": true
 		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+			"dev": true
+		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -538,53 +932,61 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
-			}
-		},
 		"chalk": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.2.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"ci-info": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
 			"dev": true
 		},
-		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
-				"wordwrap": "0.0.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
-					"optional": true
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
+			}
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"co": {
@@ -599,10 +1001,20 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
 		"color-convert": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
@@ -615,13 +1027,26 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
+		},
+		"commander": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"dev": true,
+			"optional": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -629,22 +1054,25 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-			"dev": true
-		},
 		"convert-source-map": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -659,44 +1087,24 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
-			}
-		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
-			"requires": {
-				"boom": "5.2.0"
-			},
-			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
-					"requires": {
-						"hoek": "4.2.1"
-					}
-				}
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cssom": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"dashdash": {
@@ -705,7 +1113,31 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"debug": {
@@ -723,6 +1155,12 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -735,17 +1173,69 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
 		"delayed-stream": {
@@ -760,7 +1250,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-newline": {
@@ -770,9 +1260,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-			"integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"domexception": {
@@ -781,50 +1271,51 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"error-ex": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -834,16 +1325,16 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -862,9 +1353,9 @@
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
 		"estraverse": {
@@ -880,12 +1371,12 @@
 			"dev": true
 		},
 		"exec-sh": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"dev": true,
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.2.0"
 			}
 		},
 		"execa": {
@@ -894,13 +1385,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -915,7 +1406,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -924,28 +1415,49 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expect": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
-			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"jest-diff": "22.4.0",
-				"jest-get-type": "22.1.0",
-				"jest-matcher-utils": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-regex-util": "22.1.0"
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^22.4.3",
+				"jest-get-type": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"jest-message-util": "^22.4.3",
+				"jest-regex-util": "^22.4.3"
 			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"extglob": {
 			"version": "0.3.2",
@@ -953,7 +1465,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -963,9 +1475,9 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
@@ -986,7 +1498,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"filename-regex": {
@@ -1001,21 +1513,21 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"find-up": {
@@ -1024,7 +1536,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"for-in": {
@@ -1039,14 +1551,8 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -1055,14 +1561,23 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs.realpath": {
@@ -1072,31 +1587,21 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.9.2",
-				"node-pre-gyp": "0.6.39"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
@@ -1104,103 +1609,37 @@
 					"dev": true
 				},
 				"aproba": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true,
-					"dev": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
-				"caseless": {
-					"version": "0.12.0",
+				"brace-expansion": {
+					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
 				},
-				"co": {
-					"version": "4.6.0",
+				"chownr": {
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1209,14 +1648,6 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"dev": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
@@ -1231,35 +1662,11 @@
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
 					"dev": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
+					"optional": true
 				},
 				"debug": {
-					"version": "2.6.8",
+					"version": "2.6.9",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1268,15 +1675,10 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
@@ -1285,74 +1687,25 @@
 					"optional": true
 				},
 				"detect-libc": {
-					"version": "1.0.2",
+					"version": "1.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
+				"fs-minipass": {
+					"version": "1.2.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
 					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
@@ -1360,65 +1713,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -1427,40 +1743,32 @@
 					"dev": true,
 					"optional": true
 				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true,
-					"dev": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
+				"iconv-lite": {
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1469,7 +1777,7 @@
 					"dev": true
 				},
 				"ini": {
-					"version": "1.3.4",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1479,113 +1787,45 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true,
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.7"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
 					"dev": true
+				},
+				"minipass": {
+					"version": "2.3.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -1601,23 +1841,33 @@
 					"dev": true,
 					"optional": true
 				},
-				"node-pre-gyp": {
-					"version": "0.6.39",
+				"needle": {
+					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.2",
-						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.1",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.2.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -1626,32 +1876,42 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
-				"npmlog": {
-					"version": "4.1.0",
+				"npm-bundled": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
 					"dev": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1664,7 +1924,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -1680,53 +1940,37 @@
 					"optional": true
 				},
 				"osenv": {
-					"version": "0.1.4",
+					"version": "0.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true,
-					"dev": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.1",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -1738,64 +1982,48 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
+					"version": "2.3.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
-					"version": "2.6.1",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.0.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true
 				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
 				"semver": {
-					"version": "5.3.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1812,69 +2040,31 @@
 					"dev": true,
 					"optional": true
 				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "~5.1.0"
 					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -1884,92 +2074,42 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.2"
 					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
-				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true
 				}
@@ -1982,9 +2122,9 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"get-stream": {
@@ -1993,27 +2133,33 @@
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -2022,8 +2168,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -2032,7 +2178,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"globals": {
@@ -2042,9 +2188,9 @@
 			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
 		"growly": {
@@ -2054,31 +2200,22 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				},
 				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"requires": {
-						"amdefine": "1.0.1"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -2089,22 +2226,22 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -2113,7 +2250,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -2122,23 +2259,71 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.1",
-				"sntp": "2.1.0"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-			"dev": true
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
@@ -2146,14 +2331,14 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
@@ -2162,7 +2347,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"http-signature": {
@@ -2171,16 +2356,19 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"import-local": {
 			"version": "1.0.0",
@@ -2188,8 +2376,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -2204,8 +2392,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -2215,12 +2403,12 @@
 			"dev": true
 		},
 		"invariant": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -2228,6 +2416,15 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -2241,28 +2438,28 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
-		},
 		"is-callable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
 			"dev": true
 		},
 		"is-ci": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.2"
+				"ci-info": "^1.5.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-date-object": {
@@ -2270,6 +2467,25 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -2283,7 +2499,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -2304,7 +2520,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -2325,7 +2541,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-number": {
@@ -2334,7 +2550,24 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"is-posix-bracket": {
@@ -2355,7 +2588,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-stream": {
@@ -2365,10 +2598,13 @@
 			"dev": true
 		},
 		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -2380,6 +2616,18 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
 			"dev": true
 		},
 		"isarray": {
@@ -2410,64 +2658,64 @@
 			"dev": true
 		},
 		"istanbul-api": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
-			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.1.2",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.2",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.1.4",
-				"js-yaml": "3.10.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.1",
+				"istanbul-lib-hook": "^1.2.2",
+				"istanbul-lib-instrument": "^1.10.2",
+				"istanbul-lib-report": "^1.1.5",
+				"istanbul-lib-source-maps": "^1.2.6",
+				"istanbul-reports": "^1.5.1",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
-			"integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
 			"dev": true
 		},
 		"istanbul-lib-hook": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"dev": true,
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
-			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.1.2",
-				"semver": "5.5.0"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.1.2",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -2482,42 +2730,48 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.1.2",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
-			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"dev": true,
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
@@ -2526,273 +2780,273 @@
 			"integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
 			"dev": true,
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "22.4.2"
+				"import-local": "^1.0.0",
+				"jest-cli": "^22.4.2"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "22.4.2",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
-					"integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
+					"version": "22.4.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.0.0",
-						"chalk": "2.3.1",
-						"exit": "0.1.2",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"import-local": "1.0.0",
-						"is-ci": "1.1.0",
-						"istanbul-api": "1.2.2",
-						"istanbul-lib-coverage": "1.1.2",
-						"istanbul-lib-instrument": "1.9.2",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "22.2.0",
-						"jest-config": "22.4.2",
-						"jest-environment-jsdom": "22.4.1",
-						"jest-get-type": "22.1.0",
-						"jest-haste-map": "22.4.2",
-						"jest-message-util": "22.4.0",
-						"jest-regex-util": "22.1.0",
-						"jest-resolve-dependencies": "22.1.0",
-						"jest-runner": "22.4.2",
-						"jest-runtime": "22.4.2",
-						"jest-snapshot": "22.4.0",
-						"jest-util": "22.4.1",
-						"jest-validate": "22.4.2",
-						"jest-worker": "22.2.2",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"realpath-native": "1.0.0",
-						"rimraf": "2.6.2",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.0",
-						"yargs": "10.1.2"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.1.14",
+						"istanbul-lib-coverage": "^1.1.1",
+						"istanbul-lib-instrument": "^1.8.0",
+						"istanbul-lib-source-maps": "^1.2.1",
+						"jest-changed-files": "^22.2.0",
+						"jest-config": "^22.4.4",
+						"jest-environment-jsdom": "^22.4.1",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^22.4.2",
+						"jest-message-util": "^22.4.0",
+						"jest-regex-util": "^22.1.0",
+						"jest-resolve-dependencies": "^22.1.0",
+						"jest-runner": "^22.4.4",
+						"jest-runtime": "^22.4.4",
+						"jest-snapshot": "^22.4.0",
+						"jest-util": "^22.4.1",
+						"jest-validate": "^22.4.4",
+						"jest-worker": "^22.2.2",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^10.0.3"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
-			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
 			"dev": true,
 			"requires": {
-				"throat": "4.1.0"
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
-			"integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "22.4.1",
-				"jest-environment-node": "22.4.1",
-				"jest-get-type": "22.1.0",
-				"jest-jasmine2": "22.4.2",
-				"jest-regex-util": "22.1.0",
-				"jest-resolve": "22.4.2",
-				"jest-util": "22.4.1",
-				"jest-validate": "22.4.2",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^22.4.1",
+				"jest-environment-node": "^22.4.1",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^22.4.4",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-diff": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
-			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"diff": "3.4.0",
-				"jest-get-type": "22.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-docblock": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
-			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
-			"integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.2.0",
-				"jest-util": "22.4.1",
-				"jsdom": "11.6.2"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
-			"integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.2.0",
-				"jest-util": "22.4.1"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3"
 			}
 		},
 		"jest-get-type": {
-			"version": "22.1.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
-			"integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
-			"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "22.4.0",
-				"jest-serializer": "22.4.0",
-				"jest-worker": "22.2.2",
-				"micromatch": "2.3.11",
-				"sane": "2.4.1"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-docblock": "^22.4.3",
+				"jest-serializer": "^22.4.3",
+				"jest-worker": "^22.4.3",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
-			"integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"co": "4.6.0",
-				"expect": "22.4.0",
-				"graceful-fs": "4.1.11",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "22.4.0",
-				"jest-matcher-utils": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-snapshot": "22.4.0",
-				"jest-util": "22.4.1",
-				"source-map-support": "0.5.3"
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^22.4.0",
+				"graceful-fs": "^4.1.11",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-snapshot": "^22.4.0",
+				"jest-util": "^22.4.1",
+				"source-map-support": "^0.5.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
-			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "22.4.0"
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
-			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-get-type": "22.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-message-util": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
-			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"chalk": "2.3.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
-			"integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "22.1.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
-			"integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
-			"integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.3.1"
+				"browser-resolve": "^1.11.2",
+				"chalk": "^2.0.1"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "22.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
-			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "22.1.0"
+				"jest-regex-util": "^22.4.3"
 			}
 		},
 		"jest-runner": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
-			"integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"dev": true,
 			"requires": {
-				"exit": "0.1.2",
-				"jest-config": "22.4.2",
-				"jest-docblock": "22.4.0",
-				"jest-haste-map": "22.4.2",
-				"jest-jasmine2": "22.4.2",
-				"jest-leak-detector": "22.4.0",
-				"jest-message-util": "22.4.0",
-				"jest-runtime": "22.4.2",
-				"jest-util": "22.4.1",
-				"jest-worker": "22.2.2",
-				"throat": "4.1.0"
+				"exit": "^0.1.2",
+				"jest-config": "^22.4.4",
+				"jest-docblock": "^22.4.0",
+				"jest-haste-map": "^22.4.2",
+				"jest-jasmine2": "^22.4.4",
+				"jest-leak-detector": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-runtime": "^22.4.4",
+				"jest-util": "^22.4.1",
+				"jest-worker": "^22.2.2",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
-			"integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "22.4.1",
-				"babel-plugin-istanbul": "4.1.5",
-				"chalk": "2.3.1",
-				"convert-source-map": "1.5.1",
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.11",
-				"jest-config": "22.4.2",
-				"jest-haste-map": "22.4.2",
-				"jest-regex-util": "22.1.0",
-				"jest-resolve": "22.4.2",
-				"jest-util": "22.4.1",
-				"jest-validate": "22.4.2",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.0",
-				"slash": "1.0.0",
+				"babel-core": "^6.0.0",
+				"babel-jest": "^22.4.4",
+				"babel-plugin-istanbul": "^4.1.5",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^22.4.4",
+				"jest-haste-map": "^22.4.2",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"json-stable-stringify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "10.1.2"
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^10.0.3"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -2804,38 +3058,38 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
-			"integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
-			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-diff": "22.4.0",
-				"jest-matcher-utils": "22.4.0",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-diff": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-util": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
-			"integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.3.1",
-				"graceful-fs": "4.1.11",
-				"is-ci": "1.1.0",
-				"jest-message-util": "22.4.0",
-				"mkdirp": "0.5.1",
-				"source-map": "0.6.1"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -2847,25 +3101,25 @@
 			}
 		},
 		"jest-validate": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
-			"integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.1",
-				"jest-config": "22.4.2",
-				"jest-get-type": "22.1.0",
-				"leven": "2.1.0",
-				"pretty-format": "22.4.0"
+				"chalk": "^2.0.1",
+				"jest-config": "^22.4.4",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-worker": {
-			"version": "22.2.2",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
-			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "1.0.1"
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -2875,54 +3129,53 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"jsdom": {
-			"version": "11.6.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
-			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.4.1",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"browser-process-hrtime": "0.1.2",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.2.0",
-				"nwmatcher": "1.4.3",
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
 				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.83.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "6.4.0",
-				"ws": "4.1.0",
-				"xml-name-validator": "3.0.0"
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"jsesc": {
@@ -2938,9 +3191,9 @@
 			"dev": true
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
 		"json-stable-stringify": {
@@ -2949,7 +3202,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -2988,15 +3241,8 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true,
-			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
@@ -3004,13 +3250,13 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
 			"dev": true
 		},
 		"leven": {
@@ -3025,8 +3271,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -3035,11 +3281,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"locate-path": {
@@ -3048,14 +3294,14 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -3064,29 +3310,23 @@
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
-		},
 		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"makeerror": {
@@ -3095,8 +3335,29 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"math-random": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true
 		},
 		"mem": {
 			"version": "1.1.0",
@@ -3104,13 +3365,13 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"merge": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
 			"dev": true
 		},
 		"merge-stream": {
@@ -3119,7 +3380,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.4"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
@@ -3128,34 +3389,34 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"mime-db": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.38.0"
 			}
 		},
 		"mimic-fn": {
@@ -3170,7 +3431,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -3178,6 +3439,27 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -3195,16 +3477,61 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
 			"dev": true,
 			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
 			"dev": true
 		},
 		"node-dogstatsd": {
@@ -3219,27 +3546,39 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
 			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.5.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.0"
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
 			}
 		},
 		"normalize-path": {
@@ -3248,7 +3587,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -3257,7 +3596,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -3266,16 +3605,16 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
-		"nwmatcher": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+		"nwsapi": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
+			"integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==",
 			"dev": true
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"object-assign": {
@@ -3284,11 +3623,50 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
 		"object-keys": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
 		},
 		"object.getownpropertydescriptors": {
 			"version": "2.0.3",
@@ -3296,8 +3674,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -3306,8 +3684,25 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"once": {
@@ -3316,7 +3711,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
@@ -3325,8 +3720,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -3335,12 +3730,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -3363,9 +3758,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -3386,7 +3781,7 @@
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -3395,7 +3790,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -3410,10 +3805,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-json": {
@@ -3422,13 +3817,19 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
 			"dev": true
 		},
 		"path-exists": {
@@ -3450,9 +3851,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
 		"path-type": {
@@ -3461,9 +3862,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"performance-now": {
@@ -3490,7 +3891,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -3499,13 +3900,19 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
 		"prelude-ls": {
@@ -3521,13 +3928,13 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
-			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.0"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3556,56 +3963,46 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
 		"randomatic": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
 				},
 				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
@@ -3615,9 +4012,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -3626,8 +4023,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -3636,8 +4033,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -3646,33 +4043,33 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"realpath-native": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "1.0.0"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"regenerator-runtime": {
@@ -3687,7 +4084,17 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -3697,9 +4104,9 @@
 			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
 			"dev": true
 		},
 		"repeat-string": {
@@ -3714,57 +4121,73 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.17.11"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"require-directory": {
@@ -3791,7 +4214,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -3800,47 +4223,345 @@
 			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 			"dev": true
 		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"align-text": "0.1.4"
-			}
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.1.3"
 			}
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"dev": true
+		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"sane": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
-			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.1.3",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3856,9 +4577,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 			"dev": true
 		},
 		"set-blocking": {
@@ -3867,13 +4588,36 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -3900,13 +4644,112 @@
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 			"dev": true
 		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
 			}
 		},
 		"source-map": {
@@ -3915,13 +4758,27 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
-		"source-map-support": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
-			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3932,26 +4789,52 @@
 				}
 			}
 		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
 			"dev": true
 		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -3960,26 +4843,48 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -3993,8 +4898,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string-width": {
@@ -4003,24 +4908,18 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -4028,7 +4927,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4045,7 +4944,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -4055,12 +4954,12 @@
 			"dev": true
 		},
 		"supports-color": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-			"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-tree": {
@@ -4070,16 +4969,16 @@
 			"dev": true
 		},
 		"test-exclude": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
-			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
+			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			}
 		},
 		"throat": {
@@ -4100,13 +4999,56 @@
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
 			"dev": true
 		},
-		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"kind-of": "^3.0.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				}
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -4115,15 +5057,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-					"dev": true
-				}
+				"punycode": "^2.1.0"
 			}
 		},
 		"trim-right": {
@@ -4138,15 +5072,14 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -4154,42 +5087,130 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+			"integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"commander": "~2.20.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true,
-					"optional": true,
+					"optional": true
+				}
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
-						"window-size": "0.1.0"
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
 		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -4203,24 +5224,24 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
 		"uuid": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"verror": {
@@ -4229,9 +5250,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -4240,7 +5261,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "0.1.2"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -4249,7 +5270,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -4258,8 +5279,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -4277,32 +5298,38 @@
 			"dev": true
 		},
 		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "0.4.24"
 			}
 		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
 		"whatwg-url": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"which": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -4310,13 +5337,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true,
-			"optional": true
 		},
 		"wordwrap": {
 			"version": "0.0.3",
@@ -4330,8 +5350,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -4340,7 +5360,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -4349,9 +5369,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4360,7 +5380,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -4372,24 +5392,23 @@
 			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+			"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ws": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1"
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"xml-name-validator": {
@@ -4416,31 +5435,18 @@
 			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"dev": true,
 			"requires": {
-				"cliui": "4.0.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "8.1.0"
-			},
-			"dependencies": {
-				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"dev": true,
-					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
-					}
-				}
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^8.1.0"
 			}
 		},
 		"yargs-parser": {
@@ -4449,15 +5455,7 @@
 			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
+				"camelcase": "^4.1.0"
 			}
 		}
 	}


### PR DESCRIPTION
Jest config was required to specify "testURL", needed to upgrade jsdom,
as per the github issue defined here:
https://github.com/jsdom/jsdom/issues/2304