### PR TITLE
Allow path option to be a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,11 @@ module.exports = function (options) {
 			}
 
 			if (path !== false) {
-				statTags.push(`path:${req.path}`);
+				if (path instanceof Function) {
+					statTags.push(`path:${path(req.path)}`);
+				} else {
+					statTags.push(`path:${req.path}`);
+				}
 			}
 
 			if (response_code) {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -185,6 +185,23 @@ describe('connectDatadog', () => {
         })
       })
 
+      describe('when the path option is a function', () => {
+        it('should append the path function result to the metric tag', async () => {
+          const path = function (p) {
+            return p.split('/').slice(0, 2).join('/')
+          }
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+            `path:/another`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, path })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+      })
+
       describe('when the path option is falsy', () => {
         it('should NOT append the path to the metric tag', async () => {
           const path = false


### PR DESCRIPTION
## Summary

Allows path option to be a function. If it is then this function is applied to `req.path` in order to create the path tag.

## Motivation

There are many times when a url includes data which is not interesting from a metrics aggregation perspective. For example imagine a route `/user/:userId`. I care for the overall latency and success rate of the user path and not just for a specific user.