### PR TITLE
add circleci configuration and update the node engines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: node:8
+    working_directory: ~/node-connect-datadog
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Versions
+          command: npm version
+      - restore_cache:
+          key: v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+      - run:
+          name: Install dependencies
+          command: npm install
+      - save_cache:
+          key: v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: Run tests
+          command: npm test
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"engines": {
-    "node": ">=8"
-  },
+		"node": ">=8"
+	},
 	"dependencies": {
 		"node-dogstatsd": "0.0.6"
 	},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
 	"author": "Datadog",
 	"license": "MIT",
 	"readmeFilename": "README.md",
+	"engines": {
+    "node": ">=8"
+  },
 	"dependencies": {
 		"node-dogstatsd": "0.0.6"
 	},


### PR DESCRIPTION
This PR adds a CircleCI configuration so that we don't have to run tests locally. It also updates the Node engines in `package.json` since it didn't have a value previously.