### PR TITLE
Switch from node-dogstatsd to hot-shots

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-const DD = require("node-dogstatsd").StatsD;
+const hotShots = require("hot-shots");
 
 module.exports = function (options) {
-	let datadog = options.dogstatsd || new DD();
+	let datadog = options.dogstatsd || new hotShots.StatsD("localhost", 8125);
 	let stat = options.stat || "node.express.router";
 	let tags = options.tags || [];
 	let path = options.path || false;

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -5,7 +5,7 @@ const mockStatsDImplementation = {
   increment: jest.fn(),
 }
 
-jest.mock('node-dogstatsd', () => ({
+jest.mock('hot-shots', () => ({
   StatsD: jest.fn().mockImplementation(() => mockStatsDImplementation),
 }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -742,6 +742,15 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1472,6 +1481,12 @@
 			"requires": {
 				"bser": "^2.0.0"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -2245,6 +2260,14 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
+		},
+		"hot-shots": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.3.0.tgz",
+			"integrity": "sha512-9aSojxGXFDQG8EiRtUp7Cd/dG0vgiQ2E/dB/5B59rdEbV8++tqaa2v/OUJW7EYyplETaglnaXsjUA8DB3LFGrw==",
+			"requires": {
+				"unix-dgram": "2.0.x"
+			}
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -3392,7 +3415,6 @@
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
 			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
@@ -4680,6 +4702,16 @@
 						"to-object-path": "^0.3.0"
 					}
 				}
+			}
+		},
+		"unix-dgram": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
+			"integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+			"optional": true,
+			"requires": {
+				"bindings": "^1.3.0",
+				"nan": "^2.13.2"
 			}
 		},
 		"unset-value": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"node": ">=8"
 	},
 	"dependencies": {
+		"hot-shots": "^6.3.0",
 		"node-dogstatsd": "0.0.6"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
 		"node": ">=8"
 	},
 	"dependencies": {
-		"hot-shots": "^6.3.0",
-		"node-dogstatsd": "0.0.6"
+		"hot-shots": "^6.3.0"
 	},
 	"devDependencies": {
 		"jest": "^24.8.0"


### PR DESCRIPTION
### Description
This change switches from [node-dogstatsd](https://www.npmjs.com/package/node-dogstatsd) over to [hot-shots](https://www.npmjs.com/package/hot-shots).

### Motivation
**node-dogstatsd** has not been published for two years
**hot-shots** is actively maintained and was last published a month ago