### PR TITLE
[Fixes #14] Merge array of route paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ module.exports = function (options) {
 		return str && str.replace(REGEX_PIPE, DELIM);
 	}
 
-	function getRoutes(req, base_url) {
+	function getRoute(req, base_url) {
 		const routePath = req.route && req.route.path ? req.route.path : '';
 		const baseUrl = (base_url !== false) ? req.baseUrl : '';
 		return baseUrl + replacePipeChar(routePath);

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,15 @@ module.exports = function (options) {
 		if (str instanceof RegExp) {
 			str = str.toString();
 		}
+		
+		if (Array.isArray(str)) {
+			str = str.join(',')
+		}
 
 		return str && str.replace(REGEX_PIPE, DELIM);
 	}
 
-	function getRoute(req, base_url) {
+	function getRoutes(req, base_url) {
 		const routePath = req.route && req.route.path ? req.route.path : '';
 		const baseUrl = (base_url !== false) ? req.baseUrl : '';
 		return baseUrl + replacePipeChar(routePath);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -183,6 +183,22 @@ describe('connectDatadog', () => {
           await asyncConnectDatadogAndCallMiddleware({ response_code: true, path })
           expectConnectedToDatadog(stat, statTags, false)
         })
+
+        describe('when the path is an array of paths', () => {
+          it('should append the joined path to the metric tag', async () => {
+            req.route.path = ['/some/path', '/array/of/paths']
+            const path = true
+            const stat = 'node.express.router'
+            const statTags = [
+              `route:${req.route.path}`,
+              `response_code:${res.statusCode}`,
+              `path:${req.path}`,
+            ]
+  
+            await asyncConnectDatadogAndCallMiddleware({ response_code: true, path })
+            expectConnectedToDatadog(stat, statTags, false)
+          })
+        })
       })
 
       describe('when the path option is falsy', () => {


### PR DESCRIPTION
Hello! This closes #14 but merging an array of route paths. I took a simple approach by checking if the `str` is actually an array, and just joining the items on `,` - this would create a tag specific to that grouping of routes.

I also added a test - it fails without the change to `lib/index.js` (it throws the error from #14) but I didn't see a clear way to test against the actual end-result tag. Any ideas/suggestions there would be great!

This is currently causing some complications in the project I work on, so if there's a way we can get this published that'd be awesome. Let me know how I can help!