### PR TITLE
no more hardcoded localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Add middleware immediately before your router.
 
 All options are optional.
 
-* `dogstatsd` node-dogstatsd client. `default = new require("node-dogstatsd").StatsD()`
+* `dogstatsd_host` *string* host for node-dogstatsd client. `default = localhost`;
+* `dogstatsd_port` *number* port for node-dogstatsd client. `default = 8125`;
+* `dogstatsd` node-dogstatsd client. `default = new require("node-dogstatsd").StatsD(dogstatsd_host, dogstatsd_port)`
 * `stat` *string* name for the stat. `default = "node.express.router"`
 * `tags` *array* of tags to be added to the histogram. `default = []`
 * `path` *boolean* include path tag. `default = false`

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 const hotShots = require("hot-shots");
 
 module.exports = function (options) {
-	let datadog = options.dogstatsd || new hotShots.StatsD("localhost", 8125);
+	let dogstatsd_host = options.dogstatsd_host || "localhost";
+	let dogstatsd_port = options.dogstatsd_port || 8125;
+	let datadog = options.dogstatsd || new hotShots.StatsD(dogstatsd_host, dogstatsd_port);
 	let stat = options.stat || "node.express.router";
 	let tags = options.tags || [];
 	let path = options.path || false;


### PR DESCRIPTION
Hi this is my proposal for issue #16 

I've notived that localhost is hardcoded
`let datadog = options.dogstatsd || new hotShots.StatsD("localhost", 8125);`

I can use the options.dogstatsd to create myself a new object with correct value but it may be easier for developpers to config host and port directly.

**This is backward-compatible.**